### PR TITLE
feat: add optional MCP server for AI-assisted MDD browsing and diffing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,24 @@ jobs:
         run: cargo build --locked --verbose
       - name: Test
         run: cargo test --locked -- --show-output
+
+  build_all_features:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.88.0
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Build with all features
+        run: cargo build --locked --all-features --verbose
+      - name: Test with all features
+        run: cargo test --locked --all-features -- --show-output

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           submodules: false
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@3d52fa5c86094997f8f2d3cb4714f32f6fd23c90
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
           fail-on-clippy-error: "true"
           clippy-deny-warnings: "true"
       - name: Format and Clippy - Nightly toolchain latest
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@3d52fa5c86094997f8f2d3cb4714f32f6fd23c90
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@3d52fa5c86094997f8f2d3cb4714f32f6fd23c90
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@b90aee53ba1739e08f7991d24241b23903a8c11a
         with:
           copyright-text: "Alexander Mohr"
           license: "Apache-2.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +287,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +377,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -687,6 +716,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +896,30 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -983,7 +1124,10 @@ dependencies = [
  "clap",
  "crossterm",
  "ratatui",
+ "rmcp",
  "serde",
+ "serde_json",
+ "tokio",
  "toml 0.8.23",
 ]
 
@@ -1250,6 +1394,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -1669,6 +1819,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1893,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
@@ -1870,6 +2056,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2091,6 +2283,31 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2488,10 +2705,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 
+[features]
+mcp = ["dep:rmcp", "dep:tokio", "dep:serde_json"]
+
 [dependencies]
 cda-database = { git = "https://github.com/eclipse-opensovd/classic-diagnostic-adapter.git", rev = "c1c9db5c9b95b790fa3e905ac1c04d38880a532e" }
 cda-interfaces = { git = "https://github.com/eclipse-opensovd/classic-diagnostic-adapter.git", rev = "c1c9db5c9b95b790fa3e905ac1c04d38880a532e" }
@@ -28,6 +31,15 @@ arboard = "3"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 
+# MCP server (optional)
+rmcp = { version = "1.5", features = [
+  "server",
+  "transport-io",
+  "macros",
+], optional = true }
+tokio = { version = "1", features = ["rt", "macros"], optional = true }
+serde_json = { version = "1", optional = true }
+
 [patch.crates-io]
 flatbuffers = { git = "https://github.com/alexmohr/flatbuffers.git", rev = "0ba3307d" }
 
@@ -43,3 +55,6 @@ indexing_slicing = "deny"
 unwrap_used = "deny"
 arithmetic_side_effects = "deny"
 separated_literal_suffix = "deny"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,50 @@ mdd-ui export-diff old_ecu.mdd new_ecu.mdd -o diff_report.txt
 mdd-ui export-diff old_ecu.mdd new_ecu.mdd  # prints to stdout
 ```
 
+### MCP Server Mode
+
+mdd-ui can run as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server over stdio, allowing AI assistants to browse, search, and diff MDD databases programmatically.
+
+This requires building with the `mcp` feature:
+
+```sh
+cargo build --release --features mcp
+```
+
+Then start the server:
+
+```sh
+mdd-ui mcp
+```
+
+#### Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `load_mdd` | Load an MDD file and return an ECU summary (name, variant count, etc.). Must be called before other read tools. |
+| `browse_tree` | Navigate the tree hierarchy with optional depth limit and start index. |
+| `get_node_details` | Get detailed information (overview tables, parameters, etc.) for a node by index. |
+| `search_nodes` | Case-insensitive text search across all tree nodes. |
+| `diff_mdd` | Compare two MDD files and return an annotated diff tree. |
+| `export_diff` | Generate a full text diff report with property-level changes. |
+
+#### OpenCode Configuration
+
+To use the MCP server with [OpenCode](https://opencode.ai), add the following to your `opencode.json` (either in your project root or `~/.config/opencode/opencode.json`):
+
+```json
+{
+  "mcp": {
+    "mdd-ui": {
+      "type": "local",
+      "command": ["path/to/mdd-ui", "mcp"]
+    }
+  }
+}
+```
+
+Replace `path/to/mdd-ui` with the actual path to your built binary (e.g., `target/release/mdd-ui`).
+
 ## Keybindings
 
 ### Navigation
@@ -219,6 +263,14 @@ src/
 ├── database/            # MDD file loading and data extraction
 │   ├── mod.rs
 │   └── reader.rs
+├── diff/                # Diff functionality
+│   ├── mod.rs
+│   ├── snapshot.rs
+│   ├── compare.rs
+│   ├── diff_tree.rs
+│   └── export.rs
+├── mcp/                 # MCP server (optional, behind "mcp" feature)
+│   └── mod.rs
 └── tree/                # Tree model
     ├── mod.rs           #   build_tree entry point
     ├── builder.rs       #   TreeBuilder helper
@@ -245,6 +297,8 @@ src/
 | [clap](https://docs.rs/clap) | Command-line argument parsing |
 | [anyhow](https://docs.rs/anyhow) | Ergonomic error handling |
 | [serde](https://serde.rs) + [toml](https://docs.rs/toml) | Theme configuration deserialization |
+| [rmcp](https://github.com/modelcontextprotocol/rust-sdk) | MCP server SDK (optional, `mcp` feature) |
+| [tokio](https://tokio.rs) | Async runtime for MCP server (optional, `mcp` feature) |
 
 ## License
 

--- a/src/app/render/detail.rs
+++ b/src/app/render/detail.rs
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2026 Alexander Mohr
  */
 
-use std::rc::Rc;
+use std::{rc::Rc, sync::Arc};
 
 use ratatui::{
     Frame,
@@ -36,7 +36,7 @@ impl App {
             return;
         };
         let node_text = selected_node.text.clone();
-        let detail_sections = Rc::clone(&selected_node.detail_sections);
+        let detail_sections = Arc::clone(&selected_node.detail_sections);
 
         if detail_sections.is_empty() {
             // Draw a default/dummy pane with helpful information

--- a/src/diff/diff_tree.rs
+++ b/src/diff/diff_tree.rs
@@ -8,7 +8,7 @@
 //! request/response parameters, com-params, etc.) so the diff view shows the
 //! same rich information as browse mode, plus colour-coded change indicators.
 
-use std::{collections::HashSet, rc::Rc};
+use std::{collections::HashSet, sync::Arc};
 
 use cda_database::datatypes::DiagnosticDatabase;
 
@@ -214,7 +214,7 @@ fn merge_children(old_children: &[HierNode], new_children: &[HierNode]) -> Vec<M
                 if !inserted {
                     sections.insert(0, changes);
                 }
-                node.detail_sections = Rc::from(sections);
+                node.detail_sections = Arc::from(sections);
             }
 
             // Annotate individual table rows in matching sections with
@@ -402,7 +402,7 @@ fn annotate_section_rows(old: &TreeNode, new: &mut TreeNode) {
     // closest matching tab. For simplicity we do not create new tabs for
     // removed sections — the "Changes" summary already notes them.
 
-    new.detail_sections = Rc::from(new_sections);
+    new.detail_sections = Arc::from(new_sections);
 }
 
 /// Set `diff_status` on every row in a `DetailContent`.
@@ -936,7 +936,7 @@ fn add_summary_to_general(
     // Prepend the diff overview to the General node's existing sections
     let mut sections: Vec<DetailSectionData> = vec![diff_overview];
     sections.extend(general.node.detail_sections.iter().cloned());
-    general.node.detail_sections = Rc::from(sections);
+    general.node.detail_sections = Arc::from(sections);
 
     nodes
 }
@@ -955,7 +955,7 @@ mod tests {
             text: text.to_owned(),
             expanded: false,
             has_children,
-            detail_sections: Rc::from([]),
+            detail_sections: Arc::from([]),
             node_type: NodeType::Default,
             section_type: None,
             service_list_type: None,
@@ -975,7 +975,7 @@ mod tests {
             text: text.to_owned(),
             expanded: false,
             has_children: false,
-            detail_sections: Rc::from(sections),
+            detail_sections: Arc::from(sections),
             node_type: NodeType::Default,
             section_type: None,
             service_list_type: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@
 mod app;
 mod database;
 mod diff;
+#[cfg(feature = "mcp")]
+mod mcp;
 mod tree;
 
 use anyhow::{Context, Result, bail};
@@ -51,6 +53,9 @@ enum Command {
         #[arg(short, long)]
         output: Option<String>,
     },
+    /// Start an MCP (Model Context Protocol) server over stdio
+    #[cfg(feature = "mcp")]
+    Mcp,
 }
 
 /// Restores the terminal to its original state.
@@ -74,6 +79,8 @@ fn main() -> Result<()> {
             new_file,
             output,
         }) => run_export_diff(&old_file, &new_file, output.as_deref()),
+        #[cfg(feature = "mcp")]
+        Some(Command::Mcp) => mcp::run_mcp(),
         None => {
             let Some(mdd_file) = cli.mdd_file else {
                 bail!("No MDD file specified. Usage: mdd-ui <MDD_FILE> [--theme <THEME_FILE>]");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,437 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 Alexander Mohr
+ */
+
+//! MCP (Model Context Protocol) server for browsing and diffing MDD diagnostic databases.
+//!
+//! Exposes tools over stdio that allow LLMs to load MDD files, browse the tree
+//! structure, search nodes, view details, and compare two databases.
+
+use std::{collections::HashMap, fmt::Write as _, sync::Mutex};
+
+use anyhow::{Context, Result};
+use rmcp::{handler::server::wrapper::Parameters, schemars, tool, tool_router};
+use serde::Deserialize;
+
+use crate::{
+    database, diff,
+    tree::{self, DetailContent, DiffStatus, NodeType, TreeNode},
+};
+
+// Cached data: we load the MDD, build the tree, and store only Send-safe data.
+
+struct CachedDatabase {
+    nodes: Vec<TreeNode>,
+    ecu_name: String,
+}
+
+// Tool parameter types
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct LoadMddParams {
+    /// Absolute path to the MDD file to load
+    path: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BrowseTreeParams {
+    /// Absolute path to the MDD file (must be loaded first via `load_mdd`)
+    path: String,
+    /// Maximum tree depth to display (default: all)
+    max_depth: Option<usize>,
+    /// Index of the parent node to start browsing from (default: root)
+    start_index: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GetNodeDetailsParams {
+    /// Absolute path to the MDD file (must be loaded first via `load_mdd`)
+    path: String,
+    /// Index of the tree node (as returned by `browse_tree` or `search_nodes`)
+    node_index: usize,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SearchNodesParams {
+    /// Absolute path to the MDD file (must be loaded first via `load_mdd`)
+    path: String,
+    /// Case-insensitive search query to match against node text
+    query: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct DiffMddParams {
+    /// Absolute path to the old/reference MDD file
+    old_path: String,
+    /// Absolute path to the new MDD file
+    new_path: String,
+    /// Maximum tree depth to display (default: all)
+    max_depth: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ExportDiffParams {
+    /// Absolute path to the old/reference MDD file
+    old_path: String,
+    /// Absolute path to the new MDD file
+    new_path: String,
+}
+
+// MCP Server
+
+#[derive(Clone)]
+pub struct MddMcpServer {
+    databases: std::sync::Arc<Mutex<HashMap<String, CachedDatabase>>>,
+}
+
+impl MddMcpServer {
+    fn new() -> Self {
+        Self {
+            databases: std::sync::Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Load a database if not already cached, returning `Ok(())` or an error message.
+    fn ensure_loaded(&self, path: &str) -> std::result::Result<(), String> {
+        let mut cache = self
+            .databases
+            .lock()
+            .map_err(|e| format!("Lock poisoned: {e}"))?;
+        if cache.contains_key(path) {
+            return Ok(());
+        }
+        let db = database::load_mdd(path).map_err(|e| format!("Failed to load {path}: {e:#}"))?;
+        let (nodes, ecu_name) = tree::build_tree(&db, path);
+        cache.insert(path.to_owned(), CachedDatabase { nodes, ecu_name });
+        Ok(())
+    }
+
+    /// Get a reference to cached nodes via a closure (avoids holding the lock).
+    fn with_cache<F, R>(&self, path: &str, f: F) -> std::result::Result<R, String>
+    where
+        F: FnOnce(&CachedDatabase) -> R,
+    {
+        let cache = self
+            .databases
+            .lock()
+            .map_err(|e| format!("Lock poisoned: {e}"))?;
+        let db = cache
+            .get(path)
+            .ok_or_else(|| format!("Database not loaded: {path}. Call load_mdd first."))?;
+        Ok(f(db))
+    }
+}
+
+// Tool implementations
+
+#[tool_router(server_handler)]
+impl MddMcpServer {
+    /// Load an MDD diagnostic database file and return a summary of its contents.
+    /// This must be called before using `browse_tree`, `get_node_details`, or `search_nodes`.
+    #[tool(
+        description = "Load an MDD diagnostic database file and return a summary. Must be called \
+                       before browse_tree, get_node_details, or search_nodes."
+    )]
+    fn load_mdd(&self, Parameters(params): Parameters<LoadMddParams>) -> String {
+        if let Err(e) = self.ensure_loaded(&params.path) {
+            return format!("Error: {e}");
+        }
+        self.with_cache(&params.path, |db| {
+            let node_count = db.nodes.len();
+            let mut summary = format!(
+                "Loaded: {}\nECU: {}\nTotal nodes: {node_count}\n\nTop-level sections:",
+                params.path, db.ecu_name
+            );
+            for (i, node) in db.nodes.iter().enumerate() {
+                if node.depth == 0 {
+                    let _ = write!(summary, "\n  [{i}] {}", node.text);
+                }
+            }
+            summary
+        })
+        .unwrap_or_else(|e| format!("Error: {e}"))
+    }
+
+    /// Browse the tree structure of a loaded MDD database.
+    /// Returns an indented text representation of the node hierarchy with node indices.
+    #[tool(
+        description = "Browse the tree hierarchy of a loaded MDD database. Returns indented node \
+                       list with indices that can be used with get_node_details."
+    )]
+    fn browse_tree(&self, Parameters(params): Parameters<BrowseTreeParams>) -> String {
+        if let Err(e) = self.ensure_loaded(&params.path) {
+            return format!("Error: {e}");
+        }
+        self.with_cache(&params.path, |db| {
+            let max_depth = params.max_depth.unwrap_or(usize::MAX);
+            let start = params.start_index.unwrap_or(0);
+            let start_depth = db.nodes.get(start).map_or(0, |n| n.depth);
+            let mut output = String::new();
+            let mut skip_depth: Option<usize> = None;
+
+            for (i, node) in db.nodes.iter().enumerate().skip(start) {
+                // If we started from a specific node, stop when we
+                // return to the same or lower depth
+                if i > start && node.depth <= start_depth {
+                    break;
+                }
+                let relative_depth = node.depth.saturating_sub(start_depth);
+                if relative_depth > max_depth {
+                    continue;
+                }
+                // Skip collapsed subtrees for readability
+                if let Some(sd) = skip_depth {
+                    if node.depth > sd {
+                        continue;
+                    }
+                    skip_depth = None;
+                }
+                let indent = "  ".repeat(relative_depth);
+                let type_tag = node_type_tag(node.node_type);
+                let children_marker = if node.has_children { " ..." } else { "" };
+                let _ = writeln!(
+                    output,
+                    "{indent}{type_tag} [{i}] {}{children_marker}",
+                    node.text
+                );
+            }
+            if output.is_empty() {
+                "No nodes found at the specified location.".to_owned()
+            } else {
+                output
+            }
+        })
+        .unwrap_or_else(|e| format!("Error: {e}"))
+    }
+
+    /// Get detailed information for a specific tree node by its index.
+    /// Returns all detail sections (overview tables, parameters, etc.) as formatted text.
+    #[tool(
+        description = "Get detailed information for a specific tree node by index. Returns \
+                       formatted detail sections including overview tables, parameters, and \
+                       related data."
+    )]
+    fn get_node_details(&self, Parameters(params): Parameters<GetNodeDetailsParams>) -> String {
+        if let Err(e) = self.ensure_loaded(&params.path) {
+            return format!("Error: {e}");
+        }
+        self.with_cache(&params.path, |db| {
+            let Some(node) = db.nodes.get(params.node_index) else {
+                return format!(
+                    "Error: Node index {} out of range (0..{})",
+                    params.node_index,
+                    db.nodes.len()
+                );
+            };
+            let mut output = format!(
+                "Node: {}\nType: {:?}\nDepth: {}\n",
+                node.text, node.node_type, node.depth
+            );
+
+            if let Some(ref status) = node.diff_status {
+                let _ = writeln!(output, "Diff: {status:?}");
+            }
+
+            if node.detail_sections.is_empty() {
+                output.push_str("\n(No detail sections for this node)\n");
+                return output;
+            }
+
+            for section in node.detail_sections.iter() {
+                let _ = write!(output, "\n--- {} ---\n", section.title);
+                format_detail_content(&section.content, &mut output, 0);
+            }
+            output
+        })
+        .unwrap_or_else(|e| format!("Error: {e}"))
+    }
+
+    /// Search for tree nodes matching a query string (case-insensitive).
+    /// Returns matching nodes with their indices for use with `get_node_details`.
+    #[tool(
+        description = "Search tree nodes by text (case-insensitive). Returns matching nodes with \
+                       indices that can be used with get_node_details or browse_tree start_index."
+    )]
+    fn search_nodes(&self, Parameters(params): Parameters<SearchNodesParams>) -> String {
+        if let Err(e) = self.ensure_loaded(&params.path) {
+            return format!("Error: {e}");
+        }
+        let query_lower = params.query.to_lowercase();
+        self.with_cache(&params.path, |db| {
+            let mut results = Vec::new();
+            for (i, node) in db.nodes.iter().enumerate() {
+                if node.text.to_lowercase().contains(&query_lower) {
+                    results.push(format!(
+                        "[{i}] {} (depth:{}, type:{:?})",
+                        node.text, node.depth, node.node_type
+                    ));
+                }
+            }
+            if results.is_empty() {
+                format!("No nodes matching \"{}\"", params.query)
+            } else {
+                format!("Found {} matches:\n{}", results.len(), results.join("\n"))
+            }
+        })
+        .unwrap_or_else(|e| format!("Error: {e}"))
+    }
+
+    /// Compare two MDD databases and return a diff tree showing additions,
+    /// removals, and modifications.
+    #[allow(clippy::unused_self)]
+    #[tool(
+        description = "Compare two MDD databases and return a diff tree with change annotations \
+                       (+added, -removed, ~modified)."
+    )]
+    fn diff_mdd(&self, Parameters(params): Parameters<DiffMddParams>) -> String {
+        let db_old = match database::load_mdd(&params.old_path) {
+            Ok(db) => db,
+            Err(e) => return format!("Error loading {}: {e:#}", params.old_path),
+        };
+        let db_new = match database::load_mdd(&params.new_path) {
+            Ok(db) => db,
+            Err(e) => return format!("Error loading {}: {e:#}", params.new_path),
+        };
+
+        let (nodes, ecu_name) =
+            diff::diff_tree::build_diff_tree(&db_old, &db_new, &params.old_path, &params.new_path);
+
+        let max_depth = params.max_depth.unwrap_or(usize::MAX);
+        let mut output = format!(
+            "Diff: {} (old) vs {} (new)\nECU: {ecu_name}\n\n",
+            params.old_path, params.new_path
+        );
+
+        for (i, node) in nodes.iter().enumerate() {
+            if node.depth > max_depth {
+                continue;
+            }
+            let diff_marker = match node.diff_status {
+                Some(DiffStatus::Added) => "+ ",
+                Some(DiffStatus::Removed) => "- ",
+                Some(DiffStatus::Modified) => "~ ",
+                Some(DiffStatus::Unchanged) | None => "  ",
+            };
+            let indent = "  ".repeat(node.depth);
+            let _ = writeln!(output, "{diff_marker}{indent}[{i}] {}", node.text);
+        }
+        output
+    }
+
+    /// Export a full text diff report comparing two MDD databases.
+    #[allow(clippy::unused_self)]
+    #[tool(
+        description = "Export a detailed text diff report between two MDD databases, showing all \
+                       property changes across variants, services, parameters, etc."
+    )]
+    fn export_diff(&self, Parameters(params): Parameters<ExportDiffParams>) -> String {
+        let db_old = match database::load_mdd(&params.old_path) {
+            Ok(db) => db,
+            Err(e) => return format!("Error loading {}: {e:#}", params.old_path),
+        };
+        let db_new = match database::load_mdd(&params.new_path) {
+            Ok(db) => db,
+            Err(e) => return format!("Error loading {}: {e:#}", params.new_path),
+        };
+
+        let snap_old = match diff::snapshot::EcuSnapshot::from_database(&db_old) {
+            Ok(s) => s,
+            Err(e) => return format!("Error extracting old snapshot: {e:#}"),
+        };
+        let snap_new = match diff::snapshot::EcuSnapshot::from_database(&db_new) {
+            Ok(s) => s,
+            Err(e) => return format!("Error extracting new snapshot: {e:#}"),
+        };
+
+        let diff_result = diff::compare::compare(&snap_old, &snap_new);
+
+        let mut buf = Vec::new();
+        if let Err(e) = diff::export::write_text_report(&mut buf, &diff_result) {
+            return format!("Error writing report: {e}");
+        }
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+}
+
+// Helpers
+
+/// Short tag for a node type, used in tree display.
+const fn node_type_tag(nt: NodeType) -> &'static str {
+    match nt {
+        NodeType::Container => "[+]",
+        NodeType::SectionHeader => "[#]",
+        NodeType::Service | NodeType::ParentRefService => "[S]",
+        NodeType::Request => "[Rq]",
+        NodeType::PosResponse => "[R+]",
+        NodeType::NegResponse => "[R-]",
+        NodeType::Dop => "[D]",
+        NodeType::Job => "[J]",
+        NodeType::FunctionalClass => "[FC]",
+        NodeType::Sdg => "[SDG]",
+        NodeType::ParentRefs => "[PR]",
+        NodeType::Default => "[-]",
+    }
+}
+
+/// Format detail content as human-readable text.
+fn format_detail_content(content: &DetailContent, output: &mut String, indent: usize) {
+    let prefix = "  ".repeat(indent);
+    match content {
+        DetailContent::PlainText(lines) => {
+            for line in lines {
+                let _ = writeln!(output, "{prefix}{line}");
+            }
+        }
+        DetailContent::Table { header, rows, .. } => {
+            if !header.cells.is_empty() {
+                let _ = writeln!(output, "{prefix}{}", header.cells.join(" | "));
+                let separator: Vec<String> = header
+                    .cells
+                    .iter()
+                    .map(|c| "-".repeat(c.len().max(3)))
+                    .collect();
+                let _ = writeln!(output, "{prefix}{}", separator.join("-+-"));
+            }
+            for row in rows {
+                let row_indent = "  ".repeat(row.indent);
+                let diff_prefix = match row.diff_status {
+                    Some(DiffStatus::Added) => "+ ",
+                    Some(DiffStatus::Removed) => "- ",
+                    Some(DiffStatus::Modified) => "~ ",
+                    _ => "",
+                };
+                let _ = writeln!(
+                    output,
+                    "{prefix}{diff_prefix}{row_indent}{}",
+                    row.cells.join(" | ")
+                );
+            }
+        }
+        DetailContent::Composite(sections) => {
+            for section in sections {
+                let _ = writeln!(output, "{prefix}[{}]", section.title);
+                format_detail_content(&section.content, output, indent.saturating_add(1));
+            }
+        }
+    }
+}
+
+// Entry point
+
+/// Start the MCP server over stdio.
+pub fn run_mcp() -> Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to build tokio runtime")?;
+
+    rt.block_on(async {
+        let server = MddMcpServer::new();
+        let service = rmcp::ServiceExt::serve(server, rmcp::transport::io::stdio())
+            .await
+            .context("Failed to start MCP service")?;
+        service.waiting().await.context("MCP service error")?;
+        Ok(())
+    })
+}

--- a/src/tree/builder.rs
+++ b/src/tree/builder.rs
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2026 Alexander Mohr
  */
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::types::{DetailSectionData, NodeType, SectionType, ServiceListType, TreeNode};
 
@@ -42,7 +42,7 @@ impl TreeBuilder {
             text: cfg.text,
             expanded: cfg.expanded,
             has_children: cfg.has_children,
-            detail_sections: Rc::from(cfg.sections),
+            detail_sections: Arc::from(cfg.sections),
             node_type: cfg.node_type,
             section_type: cfg.section_type,
             service_list_type: cfg.service_list_type,

--- a/src/tree/types.rs
+++ b/src/tree/types.rs
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2026 Alexander Mohr
  */
 
-use std::{fmt, rc::Rc};
+use std::{fmt, sync::Arc};
 
 /// Sentinel value for an unset bit position in the database.
 pub(crate) const BIT_POSITION_UNSET: u32 = 255;
@@ -115,7 +115,7 @@ pub struct TreeNode {
     /// Whether this node has child nodes that can be expanded.
     pub has_children: bool,
     /// Detail sections displayed when this node is selected.
-    pub detail_sections: Rc<[DetailSectionData]>,
+    pub detail_sections: Arc<[DetailSectionData]>,
     /// Classification of this node for styling and interaction.
     pub node_type: NodeType,
     /// If this is a `SectionHeader` at depth 0, specifies which top-level section it represents

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Alexander Mohr
+
+# taplo v0.9.3 and the schemastore Cargo.toml schema both lack support for the
+# [lints] table (stabilized in Rust 1.74). Disable schema validation for
+# Cargo.toml until taplo ships an updated schema.
+[[rule]]
+include = ["**/Cargo.toml"]
+
+[rule.schema]
+enabled = false


### PR DESCRIPTION
Add an MCP (Model Context Protocol) server behind the 'mcp' compile-time feature flag, allowing AI assistants like OpenCode to programmatically load, browse, search, and diff MDD diagnostic databases over stdio.

Tools: load_mdd, browse_tree, get_node_details, search_nodes, diff_mdd, export_diff. Uses rmcp 1.5 with a single-threaded tokio runtime.

Also changes Rc to Arc for TreeNode.detail_sections to satisfy Send bounds required by the async MCP handler.

--

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
