### PR TITLE
ci: use actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
           components: clippy, rustfmt
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Install Linux system dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Install cargo-deny
@@ -67,11 +65,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Install Linux system dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build with all features

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           submodules: false
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
           fail-on-clippy-error: "true"
           clippy-deny-warnings: "true"
       - name: Format and Clippy - Nightly toolchain latest
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
         with:
           copyright-text: "Alexander Mohr"
           license: "Apache-2.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,10 @@ jobs:
           EOF
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
           targets: ${{ matrix.rust_targets }}
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
 
       - name: Install Linux system dependencies
         if: matrix.platform == 'ubuntu-22.04'


### PR DESCRIPTION
<!--
SPDX-License-Identifier: Apache-2.0
SPDX-FileCopyrightText: Alexander Mohr
-->

## Summary

- Replace `dtolnay/rust-toolchain@master` with `actions-rust-lang/setup-rust-toolchain@v1` in all CI workflows
- Remove separate `Swatinem/rust-cache@v2` steps since `setup-rust-toolchain` includes integrated caching
- Aligns with the same change in [eclipse-opensovd/classic-diagnostic-adapter#318](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/pull/318) and [eclipse-opensovd/cicd-workflows#18](https://github.com/eclipse-opensovd/cicd-workflows/pull/18)

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions

## Notes for Reviewers

Affects `build.yml` (2 occurrences) and `release.yml` (1 occurrence). The `toolchain`, `components`, and `targets` inputs are unchanged — `setup-rust-toolchain` accepts the same parameters as `dtolnay/rust-toolchain`.