### PR TITLE
chore: update cicd-workflows to e03b4a6

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           submodules: false
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
           fail-on-clippy-error: "true"
           clippy-deny-warnings: "true"
       - name: Format and Clippy - Nightly toolchain latest
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
         with:
-          copyright-text: "Alexander Mohr"
-          license: "Apache-2.0"
-          reuse-template: "mdd_ui"
+          config-path: .pre-commit-config.yml

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Alexander Mohr
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        exclude: \.(patch|diff|lock|json)$
+        args: [--markdown-linebreak-ext=md]
+      - id: mixed-line-ending
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.20.0
+    hooks:
+      - id: yamlfmt
+        args: ["-formatter", "type=basic,retain_line_breaks_single=true"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.5
+    hooks:
+      - id: ruff-check
+        args: [--output-format=full]
+      - id: ruff-format
+        args: [--diff]
+  - repo: local
+    hooks:
+      - id: taplo-format
+        name: taplo-format
+        description: Format TOML documents
+        entry: taplo format
+        language: system
+        types: [toml]
+      - id: taplo-lint
+        name: taplo-lint
+        description: Lint TOML documents
+        entry: taplo lint
+        language: system
+        types: [toml]
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v6.2.0
+    hooks:
+      - id: reuse
+  - repo: local
+    hooks:
+      - id: reuse-annotate
+        name: Add missing license headers (REUSE)
+        entry: uv run pre-commit-action/reuse-annotate-hook.py
+        args:
+          - --copyright=Alexander Mohr
+          - --license=Apache-2.0
+          - --template=mdd_ui
+          - --ignore-paths=
+        language: system
+        pass_filenames: true
+        exclude: ^(LICENSE|NOTICE|CONTRIBUTORS)$
+      - id: cargo-fmt-long-lines
+        name: Rust Format - Fix long lines and unformatted code
+        entry: bash -c '[ -f Cargo.toml ] && cargo fmt --check -- --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true || exit 0'
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-fmt-import-order
+        name: Rust Format - Fix import order
+        entry: bash -c '[ -f Cargo.toml ] && cargo fmt --check -- --config group_imports=StdExternalCrate || exit 0'
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-fmt-imports-granularity
+        name: Rust Format - Fix imports granularity
+        entry: bash -c '[ -f Cargo.toml ] && cargo fmt --check -- --config imports_granularity=Crate || exit 0'
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: validate-cargo-lints
+        name: Validate Cargo Lints
+        entry: uv run shared-lints/check_cargo_lints.py Cargo.toml
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: no-unicode-check
+        name: No Unicode characters allowed
+        entry: uv run pre-commit-action/no-unicode-check.py
+        language: system
+        files: '\.(py|yml|toml|jinja2)$'
+        pass_filenames: true

--- a/deny.toml
+++ b/deny.toml
@@ -19,8 +19,8 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-  # rand 0.7.3 is a build-time-only dep via tauri's internal kuchikiki fork →
-  # phf_codegen 0.8.0 → phf_generator 0.8.0. No fix exists in the 0.7.x series
+  # rand 0.7.3 is a build-time-only dep via tauri's internal kuchikiki fork ->
+  # phf_codegen 0.8.0 -> phf_generator 0.8.0. No fix exists in the 0.7.x series
   # and the advisory conditions (custom logger calling rand::rng() during reseed)
   # cannot be triggered inside a build script.
   { id = "RUSTSEC-2026-0097", reason = "build-time only via tauri/phf_codegen 0.8; advisory conditions are unreachable in a build-script context" },


### PR DESCRIPTION
## Summary

- Updates `eclipse-opensovd/cicd-workflows` pin from `59d8665` to `e03b4a6` in both `pr-checks.yml` and `pre-commit.yaml`
- The new revision fixes broken `no-unicode-check` and `reuse-annotate` hook entry paths that failed with "Failed to spawn" errors when running from the repo root