### PR TITLE
feat: add Escape key cancellation for file loading operations

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -172,6 +172,15 @@ async function openDiff() {
 }
 
 function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && store.loading) {
+    e.preventDefault();
+    e.stopPropagation();
+    api.cancelLoad();
+    store.loading = false;
+    store.status = "Load cancelled";
+    return;
+  }
+
   const mod = isMac ? e.metaKey : e.ctrlKey;
 
   if (mod && e.key === 'w') {
@@ -239,6 +248,7 @@ function onSplitMouseDown() {
         <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
       </svg>
       <span class="mt-3 text-sm text-neutral-400">Loading…</span>
+      <span class="mt-1 text-xs text-neutral-500">Press Esc to cancel</span>
     </div>
     <!-- Welcome screen -->
     <template v-if="!store.fileLoaded">

--- a/frontend/src/api/commands.ts
+++ b/frontend/src/api/commands.ts
@@ -104,6 +104,10 @@ export async function loadMdd(path: string): Promise<LoadResult> {
   return invoke<LoadResult>("load_mdd", { path });
 }
 
+export async function cancelLoad(): Promise<void> {
+  return invoke("cancel_load");
+}
+
 export async function loadDiff(
   oldPath: string,
   newPath: string,

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -258,7 +258,9 @@ export const useAppStore = defineStore("app", () => {
         udsLoading.value = false;
       });
     } catch (e) {
-      status.value = `Error: ${e}`;
+      if (String(e) !== "Cancelled") {
+        status.value = `Error: ${e}`;
+      }
     } finally {
       loading.value = false;
     }
@@ -286,7 +288,9 @@ export const useAppStore = defineStore("app", () => {
       }
       await refreshOpenTabs();
     } catch (e) {
-      status.value = `Error: ${e}`;
+      if (String(e) !== "Cancelled") {
+        status.value = `Error: ${e}`;
+      }
     } finally {
       loading.value = false;
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,7 +4,15 @@
 // Tauri commands require owned types for JSON deserialization and state injection.
 #![allow(clippy::needless_pass_by_value)]
 
-use std::{collections::HashMap, fs, path::PathBuf, sync::Mutex};
+use std::{
+    collections::HashMap,
+    fs,
+    path::PathBuf,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use mdd_core::{
     tree::{
@@ -244,9 +252,17 @@ pub struct UdsState(
 
 pub struct InitialFile(pub Mutex<Option<String>>);
 
+pub struct LoadCancellation(pub Mutex<Option<Arc<AtomicBool>>>);
+
 impl Default for AppState {
     fn default() -> Self {
         Self(Mutex::new(TabManager::default()))
+    }
+}
+
+impl Default for LoadCancellation {
+    fn default() -> Self {
+        Self(Mutex::new(None))
     }
 }
 
@@ -584,7 +600,11 @@ fn to_visible_nodes(state: &CoreState) -> Vec<VisibleNode> {
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub async fn load_mdd(path: String, state: State<'_, AppState>) -> Result<LoadResult, String> {
+pub async fn load_mdd(
+    path: String,
+    state: State<'_, AppState>,
+    cancel: State<'_, LoadCancellation>,
+) -> Result<LoadResult, String> {
     // If the file is already open in a tab, switch to it
     {
         let mut manager = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
@@ -607,7 +627,12 @@ pub async fn load_mdd(path: String, state: State<'_, AppState>) -> Result<LoadRe
         }
     }
 
-    // Return the path from the blocking task so we don't need to clone it
+    let cancelled = Arc::new(AtomicBool::new(false));
+    {
+        let mut guard = cancel.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+        *guard = Some(Arc::clone(&cancelled));
+    }
+
     let (nodes, ecu_name, file_path) =
         tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
             let db = mdd_core::database::load_mdd(&path)
@@ -617,6 +642,15 @@ pub async fn load_mdd(path: String, state: State<'_, AppState>) -> Result<LoadRe
         })
         .await
         .map_err(|e| format!("Thread error: {e}"))??;
+
+    {
+        let mut guard = cancel.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+        *guard = None;
+    }
+
+    if cancelled.load(Ordering::Relaxed) {
+        return Err("Cancelled".to_owned());
+    }
 
     let node_count = nodes.len();
     let display_name = PathBuf::from(&file_path)
@@ -663,7 +697,14 @@ pub async fn load_diff(
     old_path: String,
     new_path: String,
     state: State<'_, AppState>,
+    cancel: State<'_, LoadCancellation>,
 ) -> Result<LoadResult, String> {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    {
+        let mut guard = cancel.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+        *guard = Some(Arc::clone(&cancelled));
+    }
+
     let (nodes, ecu_name, old, new) =
         tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
             let db_old = mdd_core::database::load_mdd(&old_path)
@@ -676,6 +717,15 @@ pub async fn load_diff(
         })
         .await
         .map_err(|e| format!("Thread error: {e}"))??;
+
+    {
+        let mut guard = cancel.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+        *guard = None;
+    }
+
+    if cancelled.load(Ordering::Relaxed) {
+        return Err("Cancelled".to_owned());
+    }
 
     let node_count = nodes.len();
 
@@ -722,6 +772,15 @@ pub async fn load_diff(
         visible,
         is_diff: true,
     })
+}
+
+#[tauri::command]
+pub fn cancel_load(state: State<'_, LoadCancellation>) -> Result<(), String> {
+    let guard = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+    if let Some(flag) = guard.as_ref() {
+        flag.store(true, Ordering::Relaxed);
+    }
+    Ok(())
 }
 
 #[tauri::command]

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ fn run_tauri_app(initial_file: Option<String>) {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(commands::AppState::default())
+        .manage(commands::LoadCancellation::default())
         .manage(commands::UdsState(tauri::async_runtime::Mutex::new(
             std::collections::HashMap::new(),
         )))
@@ -82,6 +83,7 @@ fn run_tauri_app(initial_file: Option<String>) {
         .invoke_handler(tauri::generate_handler![
             commands::load_mdd,
             commands::load_diff,
+            commands::cancel_load,
             commands::get_visible_nodes,
             commands::get_node_detail,
             commands::get_node_variant,


### PR DESCRIPTION
## Summary

- Adds ability to cancel in-progress file loading (MDD and diff) by pressing Escape
- Implements `LoadCancellation` state with `AtomicBool` flag in the Rust backend and a `cancel_load` Tauri command
- Frontend shows "Press Esc to cancel" hint during loading and suppresses "Cancelled" error messages in the status bar